### PR TITLE
feat: accept negative modifier weights

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -161,10 +161,6 @@ export function main(command?: string): void {
         .join(", ")}]`
     );
 
-    printBuskResult(
-      result,
-      weightedModifiers,
-      desiredEffects
-    );
+    printBuskResult(result, weightedModifiers, desiredEffects);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Args } from "grimoire-kolmafia";
-import { Effect, Modifier, myPath, print, toEffect, toModifier } from "kolmafia";
+import { Effect, Modifier, myPath, print, toEffect } from "kolmafia";
 import { $effects, $path, get, have, NumericModifier, sinceKolmafiaRevision } from "libram";
 import {
   findOptimalOutfitPower,
@@ -163,7 +163,7 @@ export function main(command?: string): void {
 
     printBuskResult(
       result,
-      Object.keys(weightedModifiers).map((mod) => toModifier(mod)),
+      weightedModifiers,
       desiredEffects
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,14 +76,12 @@ function parseWeightedModifiers(input: string): Partial<Record<NumericModifier, 
 
   for (const part of parts) {
     // Try to match weighted, e.g. "5 Meat Drop"
-    const weightedMatch = part.match(/^(\d+)\s+(.+)$/);
+    const weightedMatch = part.match(/^(-)?(\d+)?\s*(.+)$/);
     if (weightedMatch) {
-      const weight = Number(weightedMatch[1]);
-      const modifierName = weightedMatch[2].trim() as NumericModifier;
-      result[modifierName] = weight;
-    } else {
-      // Default weight 1 for singular modifier e.g. "Meat Drop"
-      result[part as NumericModifier] = 1;
+      const sign = weightedMatch[1] === "-" ? -1 : 1;
+      const weight = weightedMatch[2] === undefined ? 1 : Number(weightedMatch[2]);
+      const modifierName = weightedMatch[3].trim() as NumericModifier;
+      result[modifierName] = sign * weight;
     }
   }
   return result;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ import {
   print,
   Slot,
   toEffect,
+  toModifier,
   toSlot,
 } from "kolmafia";
 import {
@@ -80,7 +81,7 @@ function multipliers(slot: Slot): number {
 
 export function printBuskResult(
   result: BuskResult | null,
-  modifiers: Modifier[],
+  modifiers: Partial<Record<NumericModifier, number>>,
   desiredEffects: Effect[] = []
 ): void {
   if (!result) {
@@ -101,13 +102,15 @@ export function printBuskResult(
     $modifier`Familiar Experience`,
   ];
 
+  const modKeys = Object.keys(modifiers).map((mod) => toModifier(mod));
+
   for (const { effects, daRaw, buskIndex } of bestBusks) {
     const desiredMatches = effects.filter((e) => desiredEffects.includes(e));
     print(`Power ${daRaw} Busk ${buskIndex + 1}`);
 
     // Calculate total buff per weighted modifier
     const weightedTotals = new Map<Modifier, number>();
-    for (const mod of modifiers) {
+    for (const mod of modKeys) {
       const total = sum(effects, (ef) => numericModifier(ef, mod));
       weightedTotals.set(mod, total);
     }
@@ -127,8 +130,8 @@ export function printBuskResult(
     print(`Total buffs: ${totalBuffsStr}`);
 
     // For each weighted modifier, print contributing effects
-    for (const mod of modifiers) {
-      const contributingEffects = effects.filter((e) => numericModifier(e, mod) > 0);
+    for (const mod of modKeys) {
+      const contributingEffects = effects.filter((e) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0);
       if (contributingEffects.length === 0) continue;
 
       print(`${mod.name}:`);
@@ -137,7 +140,7 @@ export function printBuskResult(
 
     // Optionally print other useful modifiers if args.othermodifiers is true
     if (othermodifiers) {
-      const otherMods = otherModifiersList.filter((mod) => !modifiers.includes(mod));
+      const otherMods = otherModifiersList.filter((mod) => !modKeys.includes(mod));
       if (otherMods.length > 0) {
         print(`Other Useful Modifiers:`);
         for (const mod of otherMods) {
@@ -149,7 +152,7 @@ export function printBuskResult(
       }
     }
     const usefulEffects = effects.filter((e) =>
-      modifiers.some((mod) => numericModifier(e, mod) > 0)
+      modKeys.some((mod) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0)
     );
     const otherEffects = effects.filter(
       (e) => !desiredEffects.includes(e) && !usefulEffects.includes(e)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,7 +131,9 @@ export function printBuskResult(
 
     // For each weighted modifier, print contributing effects
     for (const mod of modKeys) {
-      const contributingEffects = effects.filter((e) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0);
+      const contributingEffects = effects.filter(
+        (e) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0
+      );
       if (contributingEffects.length === 0) continue;
 
       print(`${mod.name}:`);


### PR DESCRIPTION
For example, `busker-solver modifiers="-Mana Cost" allbusks` now works and shows that power 130, busk 3 gives Dreams and Lights.