### PR TITLE
Allow boolean modifiers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Args } from "grimoire-kolmafia";
-import { Effect, Modifier, myPath, print, toEffect } from "kolmafia";
+import { Effect, Modifier, myPath, print, toEffect, toModifier } from "kolmafia";
 import { $effects, $path, get, have, NumericModifier, sinceKolmafiaRevision } from "libram";
 import {
   findOptimalOutfitPower,
@@ -68,10 +68,10 @@ export let test = false;
 export let pathpower = 0;
 export let owned = false;
 
-function parseWeightedModifiers(input: string): Map<NumericModifier, number> {
-  if (!input.trim()) return new Map<NumericModifier, number>();
+function parseWeightedModifiers(input: string): Map<Modifier, number> {
+  if (!input.trim()) return new Map<Modifier, number>();
 
-  const result = new Map<NumericModifier, number>();
+  const result = new Map<Modifier, number>();
   const parts = input.split(",").map((s) => s.trim());
 
   for (const part of parts) {
@@ -80,8 +80,8 @@ function parseWeightedModifiers(input: string): Map<NumericModifier, number> {
     if (weightedMatch) {
       const sign = weightedMatch[1] === "-" ? -1 : 1;
       const weight = weightedMatch[2] === undefined ? 1 : Number(weightedMatch[2]);
-      const modifierName = weightedMatch[3].trim() as NumericModifier;
-      result.set(modifierName, sign * weight);
+      const modifier = toModifier(weightedMatch[3].trim());
+      result.set(modifier, sign * weight);
     }
   }
   return result;
@@ -140,7 +140,7 @@ export function main(command?: string): void {
     const weightedModifiers =
       args.modifiers !== Modifier.none.name
         ? parseWeightedModifiers(args.modifiers)
-        : new Map<NumericModifier, number>();
+        : new Map<Modifier, number>();
 
     const valuerFn = normalizeEffectValuer(hybridEffectValuer(desiredEffects, weightedModifiers));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,10 +161,6 @@ export function main(command?: string): void {
         .join(", ")}]`
     );
 
-    printBuskResult(
-      result,
-      weightedModifiers,
-      desiredEffects
-    );
+    printBuskResult(result, weightedModifiers, desiredEffects);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { Args } from "grimoire-kolmafia";
 import { Effect, Modifier, myPath, print, toEffect, toModifier } from "kolmafia";
-import { $effects, $path, get, have, NumericModifier, sinceKolmafiaRevision } from "libram";
+import { $effects, $path, get, have, sinceKolmafiaRevision } from "libram";
 import {
   findOptimalOutfitPower,
   hybridEffectValuer,
@@ -81,7 +81,11 @@ function parseWeightedModifiers(input: string): Map<Modifier, number> {
       const sign = weightedMatch[1] === "-" ? -1 : 1;
       const weight = weightedMatch[2] === undefined ? 1 : Number(weightedMatch[2]);
       const modifier = toModifier(weightedMatch[3].trim());
-      result.set(modifier, sign * weight);
+      if (modifier.type === "numeric" || modifier.type === "boolean") {
+        result.set(modifier, sign * weight);
+      } else {
+        print(`Error: modifier '${weightedMatch[3]}' not numeric or boolean`);
+      }
     }
   }
   return result;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Args } from "grimoire-kolmafia";
-import { Effect, Modifier, myPath, print, toEffect, toModifier } from "kolmafia";
+import { Effect, Modifier, myPath, print, toEffect } from "kolmafia";
 import { $effects, $path, get, have, NumericModifier, sinceKolmafiaRevision } from "libram";
 import {
   findOptimalOutfitPower,
@@ -163,7 +163,7 @@ export function main(command?: string): void {
 
     printBuskResult(
       result,
-      Object.keys(weightedModifiers).map((mod) => toModifier(mod)),
+      weightedModifiers,
       desiredEffects
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,10 +68,10 @@ export let test = false;
 export let pathpower = 0;
 export let owned = false;
 
-function parseWeightedModifiers(input: string): Partial<Record<NumericModifier, number>> {
-  if (!input.trim()) return {};
+function parseWeightedModifiers(input: string): Map<NumericModifier, number> {
+  if (!input.trim()) return new Map<NumericModifier, number>();
 
-  const result: Partial<Record<NumericModifier, number>> = {};
+  const result = new Map<NumericModifier, number>();
   const parts = input.split(",").map((s) => s.trim());
 
   for (const part of parts) {
@@ -81,7 +81,7 @@ function parseWeightedModifiers(input: string): Partial<Record<NumericModifier, 
       const sign = weightedMatch[1] === "-" ? -1 : 1;
       const weight = weightedMatch[2] === undefined ? 1 : Number(weightedMatch[2]);
       const modifierName = weightedMatch[3].trim() as NumericModifier;
-      result[modifierName] = sign * weight;
+      result.set(modifierName, sign * weight);
     }
   }
   return result;
@@ -138,7 +138,9 @@ export function main(command?: string): void {
   if (args.effects !== Effect.none.name || args.modifiers !== Modifier.none.name) {
     const desiredEffects = args.effects !== Effect.none.name ? parseEffects(args.effects) : [];
     const weightedModifiers =
-      args.modifiers !== Modifier.none.name ? parseWeightedModifiers(args.modifiers) : {};
+      args.modifiers !== Modifier.none.name
+        ? parseWeightedModifiers(args.modifiers)
+        : new Map<NumericModifier, number>();
 
     const valuerFn = normalizeEffectValuer(hybridEffectValuer(desiredEffects, weightedModifiers));
 
@@ -156,7 +158,7 @@ export function main(command?: string): void {
     print(
       `Hybrid strategy: prioritizing effects [${desiredEffects
         .map((e) => e.name)
-        .join(", ")}], fallback modifiers [${Object.entries(weightedModifiers)
+        .join(", ")}], fallback modifiers [${[...weightedModifiers.entries()]
         .map(([m, w]) => `${w}×${m}`)
         .join(", ")}]`
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,14 +76,12 @@ function parseWeightedModifiers(input: string): Partial<Record<NumericModifier, 
 
   for (const part of parts) {
     // Try to match weighted, e.g. "5 Meat Drop"
-    const weightedMatch = part.match(/^(\d+)\s+(.+)$/);
+    const weightedMatch = part.match(/^(-)?(\d+)?\s*(.+)$/);
     if (weightedMatch) {
-      const weight = Number(weightedMatch[1]);
-      const modifierName = weightedMatch[2].trim() as NumericModifier;
-      result[modifierName] = weight;
-    } else {
-      // Default weight 1 for singular modifier e.g. "Meat Drop"
-      result[part as NumericModifier] = 1;
+      const sign = weightedMatch[1] === "-" ? -1 : 1;
+      const weight = weightedMatch[2] === undefined ? 1 : Number(weightedMatch[2]);
+      const modifierName = weightedMatch[3].trim() as NumericModifier;
+      result[modifierName] = sign * weight;
     }
   }
   return result;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,6 @@ import {
   have as have_,
   logger,
   maxBy,
-  NumericModifier,
   sum,
 } from "libram";
 import {
@@ -81,7 +80,7 @@ function multipliers(slot: Slot): number {
 
 export function printBuskResult(
   result: BuskResult | null,
-  modifiers: Map<NumericModifier, number>,
+  modifiers: Map<Modifier, number>,
   desiredEffects: Effect[] = []
 ): void {
   if (!result) {
@@ -102,7 +101,7 @@ export function printBuskResult(
     $modifier`Familiar Experience`,
   ];
 
-  const modKeys = [...modifiers.keys()].map((mod) => toModifier(mod));
+  const modKeys = [...modifiers.keys()];
 
   for (const { effects, daRaw, buskIndex } of bestBusks) {
     const desiredMatches = effects.filter((e) => desiredEffects.includes(e));
@@ -132,7 +131,7 @@ export function printBuskResult(
     // For each weighted modifier, print contributing effects
     for (const mod of modKeys) {
       const contributingEffects = effects.filter(
-        (e) => numericModifier(e, mod) * modifiers.get(mod.name as NumericModifier)! > 0
+        (e) => numericModifier(e, mod) * modifiers.get(mod)! > 0
       );
       if (contributingEffects.length === 0) continue;
 
@@ -154,9 +153,7 @@ export function printBuskResult(
       }
     }
     const usefulEffects = effects.filter((e) =>
-      modKeys.some(
-        (mod) => numericModifier(e, mod) * modifiers.get(mod.name as NumericModifier)! > 0
-      )
+      modKeys.some((mod) => numericModifier(e, mod) * modifiers.get(mod)! > 0)
     );
     const otherEffects = effects.filter(
       (e) => !desiredEffects.includes(e) && !usefulEffects.includes(e)
@@ -182,7 +179,7 @@ export function printBuskResult(
 
 export function makeBuskResultFromPowers(
   powers: number[],
-  weightedModifiers: Map<NumericModifier, number>,
+  weightedModifiers: Map<Modifier, number>,
   uselessEffects: Effect[],
   buskStartIndex = get("_beretBuskingUses", 0)
 ): BuskResult {
@@ -214,7 +211,7 @@ export function makeBuskResultFromPowers(
 
 export function hybridEffectValuer(
   desiredEffects: Effect[],
-  weightedModifiers: Map<NumericModifier, number>
+  weightedModifiers: Map<Modifier, number>
 ): (effect: Effect, duration: number, all?: [Effect, number][]) => number {
   const wantedSet = new Set(desiredEffects);
   return (effect, duration) => {
@@ -250,7 +247,7 @@ export function normalizeEffectValuer(
 }
 
 export type EffectValuer =
-  | Map<NumericModifier, number>
+  | Map<Modifier, number>
   | ((effect: Effect, duration: number) => number)
   | Effect[];
 
@@ -331,7 +328,7 @@ export function findOptimalOutfitPower(
  * @returns The power-sum at which you'll find the optimal busk for this situation.
  */
 export function findOptimalOutfitPower(
-  weightedModifiers: Map<NumericModifier, number>,
+  weightedModifiers: Map<Modifier, number>,
   buskUses?: number,
   uselessEffects?: Effect[],
   buyItem?: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ import {
   print,
   Slot,
   toEffect,
+  toModifier,
   toSlot,
 } from "kolmafia";
 import {
@@ -80,7 +81,7 @@ function multipliers(slot: Slot): number {
 
 export function printBuskResult(
   result: BuskResult | null,
-  modifiers: Modifier[],
+  modifiers: Partial<Record<NumericModifier, number>>,
   desiredEffects: Effect[] = []
 ): void {
   if (!result) {
@@ -101,13 +102,15 @@ export function printBuskResult(
     $modifier`Familiar Experience`,
   ];
 
+  const modKeys = Object.keys(modifiers).map((mod) => toModifier(mod));
+
   for (const { effects, daRaw, buskIndex } of bestBusks) {
     const desiredMatches = effects.filter((e) => desiredEffects.includes(e));
     print(`Power ${daRaw} Busk ${buskIndex + 1}`);
 
     // Calculate total buff per weighted modifier
     const weightedTotals = new Map<Modifier, number>();
-    for (const mod of modifiers) {
+    for (const mod of modKeys) {
       const total = sum(effects, (ef) => numericModifier(ef, mod));
       weightedTotals.set(mod, total);
     }
@@ -127,8 +130,8 @@ export function printBuskResult(
     print(`Total buffs: ${totalBuffsStr}`);
 
     // For each weighted modifier, print contributing effects
-    for (const mod of modifiers) {
-      const contributingEffects = effects.filter((e) => numericModifier(e, mod) > 0);
+    for (const mod of modKeys) {
+      const contributingEffects = effects.filter((e) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0);
       if (contributingEffects.length === 0) continue;
 
       print(`${mod.name}:`);
@@ -137,7 +140,7 @@ export function printBuskResult(
 
     // Optionally print other useful modifiers if args.othermodifiers is true
     if (othermodifiers) {
-      const otherMods = otherModifiersList.filter((mod) => !modifiers.includes(mod));
+      const otherMods = otherModifiersList.filter((mod) => !modKeys.includes(mod));
       if (otherMods.length > 0) {
         print(`Other Useful Modifiers:`);
         for (const mod of otherMods) {
@@ -149,7 +152,7 @@ export function printBuskResult(
       }
     }
     const usefulEffects = effects.filter((e) =>
-      modifiers.some((mod) => numericModifier(e, mod) > 0)
+      modKeys.some((mod) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0)
     );
     const otherEffects = effects.filter(
       (e) => !desiredEffects.includes(e) && !usefulEffects.includes(e)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,7 @@ function multipliers(slot: Slot): number {
 
 export function printBuskResult(
   result: BuskResult | null,
-  modifiers: Partial<Record<NumericModifier, number>>,
+  modifiers: Map<NumericModifier, number>,
   desiredEffects: Effect[] = []
 ): void {
   if (!result) {
@@ -102,7 +102,7 @@ export function printBuskResult(
     $modifier`Familiar Experience`,
   ];
 
-  const modKeys = Object.keys(modifiers).map((mod) => toModifier(mod));
+  const modKeys = [...modifiers.keys()].map((mod) => toModifier(mod));
 
   for (const { effects, daRaw, buskIndex } of bestBusks) {
     const desiredMatches = effects.filter((e) => desiredEffects.includes(e));
@@ -132,7 +132,7 @@ export function printBuskResult(
     // For each weighted modifier, print contributing effects
     for (const mod of modKeys) {
       const contributingEffects = effects.filter(
-        (e) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0
+        (e) => numericModifier(e, mod) * modifiers.get(mod.name as NumericModifier)! > 0
       );
       if (contributingEffects.length === 0) continue;
 
@@ -154,7 +154,9 @@ export function printBuskResult(
       }
     }
     const usefulEffects = effects.filter((e) =>
-      modKeys.some((mod) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0)
+      modKeys.some(
+        (mod) => numericModifier(e, mod) * modifiers.get(mod.name as NumericModifier)! > 0
+      )
     );
     const otherEffects = effects.filter(
       (e) => !desiredEffects.includes(e) && !usefulEffects.includes(e)
@@ -180,13 +182,13 @@ export function printBuskResult(
 
 export function makeBuskResultFromPowers(
   powers: number[],
-  weightedModifiers: Partial<Record<NumericModifier, number>>,
+  weightedModifiers: Map<NumericModifier, number>,
   uselessEffects: Effect[],
   buskStartIndex = get("_beretBuskingUses", 0)
 ): BuskResult {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const effectValuer = (effect: Effect, _duration: number) =>
-    Object.entries(weightedModifiers)
+    [...weightedModifiers.entries()]
       .map(([mod, weight]) => (weight ?? 0) * numericModifier(effect, mod))
       .reduce((a, b) => a + b, 0);
 
@@ -212,7 +214,7 @@ export function makeBuskResultFromPowers(
 
 export function hybridEffectValuer(
   desiredEffects: Effect[],
-  weightedModifiers: Partial<Record<NumericModifier, number>>
+  weightedModifiers: Map<NumericModifier, number>
 ): (effect: Effect, duration: number, all?: [Effect, number][]) => number {
   const wantedSet = new Set(desiredEffects);
   return (effect, duration) => {
@@ -221,7 +223,7 @@ export function hybridEffectValuer(
       return 1e6 + duration; // Big constant ensures it's preferred
     }
     return sum(
-      Object.entries(weightedModifiers),
+      [...weightedModifiers.entries()],
       ([mod, weight]) => weight * numericModifier(effect, mod)
     );
   };
@@ -237,18 +239,18 @@ export function normalizeEffectValuer(
     const set = new Set(valuer);
     return (effect, duration) => (set.has(effect) ? duration : 0);
   } else {
-    // valuer is a weighted modifier object
+    // valuer is a map
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return (effect, _duration) =>
       sum(
-        Object.entries(valuer),
+        [...valuer.entries()],
         ([modifier, weight]) => weight * numericModifier(effect, modifier)
       );
   }
 }
 
 export type EffectValuer =
-  | Partial<Record<NumericModifier, number>>
+  | Map<NumericModifier, number>
   | ((effect: Effect, duration: number) => number)
   | Effect[];
 
@@ -329,7 +331,7 @@ export function findOptimalOutfitPower(
  * @returns The power-sum at which you'll find the optimal busk for this situation.
  */
 export function findOptimalOutfitPower(
-  weightedModifiers: Partial<Record<NumericModifier, number>>,
+  weightedModifiers: Map<NumericModifier, number>,
   buskUses?: number,
   uselessEffects?: Effect[],
   buyItem?: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,7 +131,9 @@ export function printBuskResult(
 
     // For each weighted modifier, print contributing effects
     for (const mod of modKeys) {
-      const contributingEffects = effects.filter((e) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0);
+      const contributingEffects = effects.filter(
+        (e) => numericModifier(e, mod) * modifiers[mod.name as NumericModifier]! > 0
+      );
       if (contributingEffects.length === 0) continue;
 
       print(`${mod.name}:`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import {
   beretBuskingEffects,
+  booleanModifier,
   canEquip,
   Effect,
   getPower,
@@ -12,7 +13,6 @@ import {
   print,
   Slot,
   toEffect,
-  toModifier,
   toSlot,
 } from "kolmafia";
 import {
@@ -110,7 +110,7 @@ export function printBuskResult(
     // Calculate total buff per weighted modifier
     const weightedTotals = new Map<Modifier, number>();
     for (const mod of modKeys) {
-      const total = sum(effects, (ef) => numericModifier(ef, mod));
+      const total = sum(effects, (ef) => modifier(ef, mod));
       weightedTotals.set(mod, total);
     }
 
@@ -130,9 +130,7 @@ export function printBuskResult(
 
     // For each weighted modifier, print contributing effects
     for (const mod of modKeys) {
-      const contributingEffects = effects.filter(
-        (e) => numericModifier(e, mod) * modifiers.get(mod)! > 0
-      );
+      const contributingEffects = effects.filter((e) => modifier(e, mod) * modifiers.get(mod)! > 0);
       if (contributingEffects.length === 0) continue;
 
       print(`${mod.name}:`);
@@ -145,7 +143,7 @@ export function printBuskResult(
       if (otherMods.length > 0) {
         print(`Other Useful Modifiers:`);
         for (const mod of otherMods) {
-          const total = sum(effects, (ef) => numericModifier(ef, mod));
+          const total = sum(effects, (ef) => modifier(ef, mod));
           if (total > 0) {
             print(`  ${mod.name}: ${total}`);
           }
@@ -153,7 +151,7 @@ export function printBuskResult(
       }
     }
     const usefulEffects = effects.filter((e) =>
-      modKeys.some((mod) => numericModifier(e, mod) * modifiers.get(mod)! > 0)
+      modKeys.some((mod) => modifier(e, mod) * modifiers.get(mod)! > 0)
     );
     const otherEffects = effects.filter(
       (e) => !desiredEffects.includes(e) && !usefulEffects.includes(e)
@@ -186,7 +184,7 @@ export function makeBuskResultFromPowers(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const effectValuer = (effect: Effect, _duration: number) =>
     [...weightedModifiers.entries()]
-      .map(([mod, weight]) => (weight ?? 0) * numericModifier(effect, mod))
+      .map(([mod, weight]) => (weight ?? 0) * modifier(effect, mod))
       .reduce((a, b) => a + b, 0);
 
   const busks: Busk[] = powers.map((power, index) => {
@@ -219,10 +217,7 @@ export function hybridEffectValuer(
       // Strongly prioritize desired effects
       return 1e6 + duration; // Big constant ensures it's preferred
     }
-    return sum(
-      [...weightedModifiers.entries()],
-      ([mod, weight]) => weight * numericModifier(effect, mod)
-    );
+    return sum([...weightedModifiers.entries()], ([mod, weight]) => weight * modifier(effect, mod));
   };
 }
 
@@ -239,10 +234,7 @@ export function normalizeEffectValuer(
     // valuer is a map
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return (effect, _duration) =>
-      sum(
-        [...valuer.entries()],
-        ([modifier, weight]) => weight * numericModifier(effect, modifier)
-      );
+      sum([...valuer.entries()], ([mod, weight]) => weight * modifier(effect, mod));
   }
 }
 
@@ -432,4 +424,14 @@ export function findOutfit(power: number, buyItem: boolean) {
     if (have_(item)) continue;
   }
   return outfit;
+}
+
+function modifier(effect: Effect, mod: Modifier): number {
+  if (mod.type === "numeric") {
+    return numericModifier(effect, mod);
+  } else if (mod.type === "boolean") {
+    return booleanModifier(effect, mod) ? 1 : 0;
+  }
+  // we limit to numeric or boolean modifiers when parsing
+  return 0;
 }


### PR DESCRIPTION
Builds off #16.

Allows e.g. `busker-solver allbusks modifiers="Adventure Underwater"`

```
Hybrid strategy: prioritizing effects [], fallback modifiers [1×Adventure Underwater]
Busk Info:
Power 195 Busk 1
Total buffs: Adventure Underwater: 1
Adventure Underwater:
Useful Effects: Oxygenated Blood
Other Effects: 'Roids of the Rhinoceros
Outfit: Hat - maiden wig, Shirt - SMOOCH breastplate, Pants - old sweatpants

Power 270 Busk 2
Total buffs: Adventure Underwater: 1
Adventure Underwater:
Useful Effects: Mer-kinny Flavor
Other Effects: Loco Motives, Oth-Jeal-O
Outfit: Hat - none, Shirt - Stephen's lab coat, Pants - crotchety pants

Power 430 Busk 3
Total buffs: Adventure Underwater: 1
Adventure Underwater:
Useful Effects: Mer-kinny Flavor
Other Effects: Coy to the Hurled, Lobos Fresh, Greasy Peasy, Smile of the Wombat
Outfit: Hat - none, Shirt - Unkillable Skeleton's breastplate, Pants - Boss Bat britches

Power 855 Busk 4
Total buffs: Adventure Underwater: 1
Adventure Underwater:
Useful Effects: Hyperoxygenated Blood
Other Effects: Knightlife, Elbow Sauce, Angry like the Wolf, Big Punkin', Mathematically Precise, Waxing, For Your Brain Only, Lividly Energized
Outfit: Hat - eldritch hat, Shirt - SMOOCH breastplate, Pants - weedy skirt

Power 320 Busk 5
Total buffs: Adventure Underwater: 1
Adventure Underwater:
Useful Effects: Oxygenated Blood
Other Effects: Cool Spirit, Feeling No Pain, Delighted by Autumn
Outfit: Hat - none, Shirt - flyest of shirts, Pants - Greaves of the Murk Lord
```